### PR TITLE
Tray information about sync status and storage use

### DIFF
--- a/app/core/sync.js
+++ b/app/core/sync.js
@@ -1117,6 +1117,7 @@ class Sync extends EventEmitter {
 
       this.watchChanges();
       this.saving = false;
+      globals.updateSyncing(this.syncing);
     } catch(err) {
       this.saving = false;
       throw err;

--- a/app/core/sync.js
+++ b/app/core/sync.js
@@ -263,6 +263,8 @@ class Sync extends EventEmitter {
     this.handlingRemoteChange = false;
 
     /* Notify user of changes */
+    this.account.updateUserInfo();
+
     this.notifyChanges();
 
     /* Save regularly if there are changes, even if they're worthless. At least it updates the change token. */

--- a/app/routes/settings.js
+++ b/app/routes/settings.js
@@ -40,6 +40,7 @@ router.get('/authCallback', async (req, res, next) => {
 
     await account.handleCode(code);
     core.addAccount(account);
+    gbs.updateTray();
 
     res.redirect("/settings");
   } catch(err) {

--- a/config/globals.js
+++ b/config/globals.js
@@ -15,6 +15,10 @@ class Globals extends EventEmitter {
     this.autorun = false;
   }
 
+  updateTray() {
+	  this.emit('updateTray');
+  }
+
   updateConnectivity(isConnected) {
     if (isConnected == this.connected) {
       return false;

--- a/main.js
+++ b/main.js
@@ -79,9 +79,9 @@ async function generateTrayMenu() {
     {type: 'separator'},
   ];
 
-  accounts = await core.accounts();
+  let accounts = await core.accounts();
   if(accounts[0] && accounts[0].document) {
-      account = accounts[0].document;
+      let account = accounts[0].document;
       template[template.length] = {label: account.storageUsedPercent + " % of " + account.storageLimitGiB + " GiB used", enabled: false };
       template[template.length] = {label: (gbs.syncing) ? "Syncing" : "No changes", enabled: false };
       template[template.length] = {type: 'separator'};

--- a/main.js
+++ b/main.js
@@ -50,14 +50,14 @@ function createWindow () {
   });
 }
 
-function generateTrayMenu() {
+async function generateTrayMenu() {
   if (!gbs.tray) {
     return;
   }
 
-  gbs.trayMenu = Menu.buildFromTemplate([
+  let template = [
     {
-      label: 'Preferences...',
+      label: 'Preferences',
       click () {
         if (gbs.win === null) {
           createWindow();
@@ -77,11 +77,18 @@ function generateTrayMenu() {
       checked: gbs.autorun
     },
     {type: 'separator'},
-    {
-      label: 'Quit ODrive',
-      click () {process.exit(0);}
-    }
-  ]);
+  ];
+
+  accounts = await core.accounts();
+  if(accounts[0] && accounts[0].document) {
+      account = accounts[0].document;
+      template[template.length] = {label: account.storageUsedPercent + " % of " + account.storageLimitGiB + " GiB used", enabled: false };
+      template[template.length] = {type: 'separator'};
+  }
+
+  template[template.length] = { label: 'Quit ODrive', click () {process.exit(0);} };
+
+  gbs.trayMenu = Menu.buildFromTemplate(template);
   gbs.tray.setContextMenu(gbs.trayMenu);
 }
 
@@ -95,6 +102,7 @@ async function launch() {
   generateTray();
 
   gbs.on("updateAutorun", generateTrayMenu);
+  gbs.on("updateTray", generateTrayMenu);
 
   await backend.launch();
 

--- a/main.js
+++ b/main.js
@@ -83,6 +83,7 @@ async function generateTrayMenu() {
   if(accounts[0] && accounts[0].document) {
       account = accounts[0].document;
       template[template.length] = {label: account.storageUsedPercent + " % of " + account.storageLimitGiB + " GiB used", enabled: false };
+      template[template.length] = {label: (gbs.syncing) ? "Syncing" : "No changes", enabled: false };
       template[template.length] = {type: 'separator'};
   }
 
@@ -133,6 +134,7 @@ function updateTrayIcon() {
   console.log("Updating tray icon, connected: ", gbs.connected, "syncing: ", gbs.syncing);
   let path = gbs.connected ? (gbs.syncing ? logoSync : logo) : logoGrey;
   gbs.tray.setImage(path);
+  generateTrayMenu();
 }
 
 app.commandLine.appendSwitch('host-rules', `MAP odrive.io 127.0.0.1:${backend.port}`);

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -34,7 +34,7 @@ accounts = <%- JSON.stringify(simplifiedAccounts) %>;
   <% } else { %>
     <p><ul class="list-group">
     <% for (let account of accounts) {%>
-      <li class="list-group-item"><%= account.email %> <a class="btn btn-sm btn-danger pull-right" href="/delete/<%- account.id %>"><i class="fa fa-times"></i></a></li>
+      <li class="list-group-item"><%= account.email %> (<%= account.storageUsedPercent %> % of <%= account.storageLimitGiB %> GiB used) <a class="btn btn-sm btn-danger pull-right" href="/delete/<%- account.id %>"><i class="fa fa-times"></i></a></li>
     <%
     } %>
   </ul></p>


### PR DESCRIPTION
This adds some information to the tray menu. The upper line displays the percentage of your storage quota used, as well as the storage quota itself, rounded to .1 GiB.

The line below displays the sync status. This is what it looks like in Ubuntu:
![Drive](https://user-images.githubusercontent.com/4153938/54381315-bc993100-468d-11e9-8d20-180b6c8a3403.png)

As this is my first time working with anything Electron-related, feel free to point out anything that is wrong with these changes.